### PR TITLE
Update to new SF1 census API links

### DIFF
--- a/SCRIPTS/004-GQ_gather.R
+++ b/SCRIPTS/004-GQ_gather.R
@@ -125,7 +125,7 @@ getgq_2010 = function(x){
     
     
     # Getting the census data from the API
-    totpop <- getCensus(name="sf1", # This is the Estimates datafile
+    totpop <- getCensus(name="dec/sf1", # This is the Estimates datafile
                         vintage = "2010", # Vintage year is set to the variable set above
                         key = key, # inputting my Census API key
                         vars = totpopvars, # gathering these variables

--- a/SCRIPTS/004-GQ_gather.R
+++ b/SCRIPTS/004-GQ_gather.R
@@ -470,14 +470,14 @@ getgq_2000 = function(x){
   , error=function(e){cat("ERROR :",conditionMessage(e), "\n")})
 }
 
-list <- listCensusMetadata(name = "sf1", vintage = "2010", type ="variables")
+list <- listCensusMetadata(name = "dec/sf1", vintage = "2010", type ="variables")
 dat <- pbmclapply(stateid, getgq_2010)
 GQ2010 <- rbindlist(dat)
 
 baseyear <- "2000"
 
 
-list <- listCensusMetadata(name = "sf1", vintage = baseyear, type ="variables")
+list <- listCensusMetadata(name = "dec/sf1", vintage = baseyear, type ="variables")
 dat <- pbmclapply(stateid, getgq_2000)
 GQ2000 <- rbindlist(dat)
 

--- a/SCRIPTS/004-GQ_gather.R
+++ b/SCRIPTS/004-GQ_gather.R
@@ -477,7 +477,7 @@ GQ2010 <- rbindlist(dat)
 baseyear <- "2000"
 
 
-list <- listCensusMetadata(name = "dec/sf1", vintage = baseyear, type ="variables")
+list <- listCensusMetadata(name = "sf1", vintage = baseyear, type ="variables")
 dat <- pbmclapply(stateid, getgq_2000)
 GQ2000 <- rbindlist(dat)
 


### PR DESCRIPTION
the census link to sf1 variables has changed:
https://www.census.gov/data/developers/updates/api-format-changes--sf1-2010.html

so the listCensusMetadata line in 004 requires the argument 'dec/sf1' instead of 'sf1'